### PR TITLE
Add section about required database privileges

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -12,6 +12,27 @@
 
 The module ships with database functions for calculating the host and service availability in `etc/schema/`.
 
+### Grant Required Privileges
+
+Skip this step if you used the database configuration wizard during the Icinga 2 installation.
+
+Please proceed only if you did the setup manually as described here: 
+https://icinga.com/docs/icinga2/latest/doc/02-getting-started/#setting-up-the-mysql-database
+
+The import of the SQL functions will fail due to insufficient privileges.
+The required privileges are `CREATE, CREATE ROUTINE, ALTER ROUTINE, EXECUTE`. 
+
+The following example assumes that your MySQL database is hosted on **localhost**
+and your Icinga database and user is named **icinga2**:
+
+```
+GRANT CREATE, CREATE ROUTINE, ALTER ROUTINE, EXECUTE ON icinga2.* TO 'icinga2'@'localhost';
+```
+
+Please adapt the host, database and username to your environment.
+
+### Import Database Files
+
 Please import those files into your Icinga database.
 
 The following example assumes that your Icinga database and user is named **icinga2**:
@@ -20,6 +41,8 @@ The following example assumes that your Icinga database and user is named **icin
 mysql -p -u icinga2 icinga2 < schema/slaperiods.sql
 mysql -p -u icinga2 icinga2 < schema/get_sla_ok_percent.sql
 ```
+
+Please adapt the database and username to your environment.
 
 ## Installation
 


### PR DESCRIPTION
This PR adds a section to the documentation to tackle the following error messages you will experience if you did the icinga2 database setup manually and not via the database configuration wizard that grants ALL privileges to the Icinga2 user.

```
# missing CREATE privilege
mysql -h 127.0.0.1 -p -u icinga2 icinga2 < schema/slaperiods.sql
ERROR 1142 (42000) at line 2: CREATE command denied to user 'icinga2'@'127.0.0.1' for table 'icinga_sla_periods'

# missing ALTER ROUTINE privilege
mysql -h 127.0.0.1 -p -u icinga2 icinga2 < schema/get_sla_ok_percent.sql 
ERROR 1370 (42000) at line 1: alter routine command denied to user 'icinga2'@'127.0.0.1' for routine 'icinga2.idoreports_get_sla_ok_percent'

# missing CREATE ROUTINE privilege 
# be careful, the error message is pretty ambiguous!
mysql -h 127.0.0.1 -p -u icinga2 icinga2 < schema/get_sla_ok_percent.sql 
ERROR 1044 (42000) at line 5: Access denied for user 'icinga2'@'127.0.0.1' to database 'icinga2'
```

This was tested on Ubuntu 18.04.2 with Icinga r2.10.5-1.