### PR TITLE
MySQL TAP tests

### DIFF
--- a/schema/t/00-create-db.sql
+++ b/schema/t/00-create-db.sql
@@ -1,0 +1,5 @@
+-- CREATE DATABASE icinga;
+USE tap;
+
+SELECT tap.plan(1);
+SELECT tap.has_table('tap', '__tresults__', 'MyTap is installed');

--- a/schema/t/01-statehistory.sql
+++ b/schema/t/01-statehistory.sql
@@ -1,0 +1,9 @@
+SELECT tap.plan(0);
+CREATE TABLE IF NOT EXISTS icinga_statehistory (
+    state_time timestamp NULL,
+    object_id bigint unsigned default 0,
+    state smallint default 0,
+    state_type smallint default 0,
+    last_state smallint default 0,
+    last_hard_state smallint default 0
+);

--- a/schema/t/02-icinga_objects.sql
+++ b/schema/t/02-icinga_objects.sql
@@ -1,0 +1,5 @@
+SELECT tap.plan(0);
+CREATE TABLE IF NOT EXISTS icinga_objects (
+    object_id bigint(20) unsigned NOT NULL,
+    objecttype_id bigint unsigned default 0
+);

--- a/schema/t/02-servicestatus.sql
+++ b/schema/t/02-servicestatus.sql
@@ -1,0 +1,10 @@
+SELECT tap.plan(0);
+CREATE TABLE IF NOT EXISTS icinga_servicestatus (
+    service_object_id bigint unsigned default 0,
+    status_update_time timestamp NULL,
+    current_state smallint default 0,
+    last_state_change timestamp NULL,
+    last_hard_state_change timestamp NULL,
+    last_hard_state smallint default 0,
+    state_type smallint default 0
+);

--- a/schema/t/03-hoststatus.sql
+++ b/schema/t/03-hoststatus.sql
@@ -1,0 +1,10 @@
+SELECT tap.plan(0);
+CREATE TABLE IF NOT EXISTS icinga_hoststatus (
+    host_object_id bigint unsigned default 0,
+    status_update_time timestamp NULL,
+    current_state smallint default 0,
+    last_state_change timestamp NULL,
+    last_hard_state_change timestamp NULL,
+    last_hard_state smallint default 0,
+    state_type smallint default 0
+);

--- a/schema/t/04-icinga_downtimehistory.sql
+++ b/schema/t/04-icinga_downtimehistory.sql
@@ -1,0 +1,10 @@
+SELECT tap.plan(0);
+CREATE TABLE IF NOT EXISTS icinga_downtimehistory (
+    object_id bigint unsigned default 0,
+    entry_time timestamp NULL,
+    scheduled_start_time timestamp NULL,
+    scheduled_end_time timestamp NULL,
+    was_started smallint default 0,
+    actual_start_time timestamp NULL,
+    actual_end_time timestamp NULL
+);

--- a/schema/t/04-icinga_outofsla_periods.sql
+++ b/schema/t/04-icinga_outofsla_periods.sql
@@ -1,0 +1,6 @@
+SELECT tap.plan(0);
+CREATE TABLE IF NOT EXISTS icinga_outofsla_periods (
+    timeperiod_object_id BIGINT(20) UNSIGNED NOT NULL,
+    start_time timestamp NOT NULL,
+    end_time timestamp NULL DEFAULT NULL
+);

--- a/schema/t/05-fill-hoststatus.sql
+++ b/schema/t/05-fill-hoststatus.sql
@@ -1,0 +1,5 @@
+SELECT tap.plan(1);
+INSERT INTO icinga_hoststatus(host_object_id, status_update_time, current_state, last_state_change, last_hard_state_change, last_hard_state, state_type) VALUES(1, '2019-02-10 12:00:00', 0, NULL, NULL, 0, 1);
+INSERT INTO icinga_hoststatus(host_object_id, status_update_time, current_state, last_state_change, last_hard_state_change, last_hard_state, state_type) VALUES(1, '2019-03-10 15:00:00', 1, '2019-03-05 11:00:00', '2019-03-05 12:00:00', 0, 1);
+
+SELECT tap.eq(count(*), 2, 'icinga_hoststatus has 2 rows') FROM icinga_hoststatus;

--- a/schema/t/05-fill-icinga_objects.sql
+++ b/schema/t/05-fill-icinga_objects.sql
@@ -1,0 +1,4 @@
+SELECT tap.plan(1);
+INSERT INTO icinga_objects(object_id, objecttype_id) VALUES (1,1);
+INSERT INTO icinga_objects(object_id, objecttype_id) VALUES (2,2);
+SELECT tap.eq(count(*), 2, 'icinga_objects has 2 rows') FROM icinga_objects;

--- a/schema/t/05-fill-servicestatus.sql
+++ b/schema/t/05-fill-servicestatus.sql
@@ -1,0 +1,4 @@
+SELECT tap.plan(1);
+INSERT INTO icinga_servicestatus (service_object_id, status_update_time, current_state, last_state_change, last_hard_state_change, last_hard_state, state_type) VALUES (2, '2019-02-10 12:00:00', 0, NULL, NULL, 0, 1);
+INSERT INTO icinga_servicestatus (service_object_id, status_update_time, current_state, last_state_change, last_hard_state_change, last_hard_state, state_type) VALUES (2, '2019-03-10 15:00:00', 2, '2019-03-05 11:00:00', '2019-03-05 12:00:00', 0, 1);
+SELECT tap.eq(count(*), 2, 'icinga_servicestatus has 2 rows') FROM icinga_servicestatus;

--- a/schema/t/05-fill-statehistory.sql
+++ b/schema/t/05-fill-statehistory.sql
@@ -1,0 +1,19 @@
+SELECT tap.plan(1);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-01 00:00:00', 1, 0, 1, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 11:00:00', 1, 3, 0, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 12:00:00', 1, 3, 1, 3, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 13:00:00', 1, 0, 0, 3, 3);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 14:00:00', 1, 0, 1, 0, 3);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-03-01 00:00:00', 1, 0, 1, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-03-05 11:00:00', 1, 3, 0, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-03-05 12:00:00', 1, 3, 1, 3, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-01 00:00:00', 2, 0, 1, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 11:00:00', 2, 3, 0, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 12:00:00', 2, 3, 1, 3, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 13:00:00', 2, 0, 0, 3, 3);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-02-05 14:00:00', 2, 0, 1, 0, 3);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-03-01 00:00:00', 2, 0, 1, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-03-05 11:00:00', 2, 3, 0, 0, 0);
+INSERT INTO icinga_statehistory(state_time, object_id, state, state_type, last_state, last_hard_state) VALUES('2019-03-05 12:00:00', 2, 3, 1, 3, 0);
+
+SELECT tap.eq(count(*), 16, 'icinga_statehistory has 16 rows') FROM icinga_statehistory;

--- a/schema/t/06-get_sla_ok_percent.sql
+++ b/schema/t/06-get_sla_ok_percent.sql
@@ -1,0 +1,1 @@
+../get_sla_ok_percent.sql

--- a/schema/t/07-test-func.sql
+++ b/schema/t/07-test-func.sql
@@ -1,0 +1,22 @@
+SELECT tap.plan(20);
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-05 12:00', '2019-02-05 14:00', NULL) , 0.0000,'Host 1 was down 2 out of 2 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-05 10:00', '2019-02-05 14:00', NULL) , 50.0000,'Host 1 was down 2 out of 4 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-05 10:00', '2019-02-05 18:00', NULL) , 75.0000,'Host 1 was down 2 out of 8 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-04 10:00', '2019-02-04 18:00', NULL) , 100.0000,'Host 1 was not down before 02/05 12:00');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-06 10:00', '2019-02-08 18:00', NULL) , 100.0000,'Host 1 was not down after 02/05 14:00');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-04 13:00', '2019-02-05 13:00', NULL) , 95.8333,'Host 1 was down for the last hour of checked timeframe');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-02-05 13:00', '2019-02-06 13:00', NULL) , 95.8333,'Host 1 was down for the first hour of checked timeframe');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-03-05 11:00', '2019-03-05 13:00', NULL) , 50.0000,'Host 1 was down 1 out of 2 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-03-05 12:00', '2019-03-05 13:00', NULL) , 0.0000,'Host 1 was down during that period');
+SELECT tap.eq(idoreports_get_sla_ok_percent(1,'2019-03-05 13:00', '2019-03-05 14:00', NULL) , 0.0000,'Host 1 was down during that period');
+
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-05 12:00', '2019-02-05 14:00', NULL) , 0.0000,'Service 2 was down 2 out of 2 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-05 10:00', '2019-02-05 14:00', NULL) , 50.0000,'Service 2 was down 2 out of 4 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-05 10:00', '2019-02-05 18:00', NULL) , 75.0000,'Service 2 was down 2 out of 8 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-04 10:00', '2019-02-04 18:00', NULL) , 100.0000,'Service 2 was not down before 02/05 12:00');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-06 10:00', '2019-02-08 18:00', NULL) , 100.0000,'Service 2 was not down after 02/05 14:00');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-04 13:00', '2019-02-05 13:00', NULL) , 95.8333,'Service 2 was down for the last hour of checked timeframe');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-02-05 13:00', '2019-02-06 13:00', NULL) , 95.8333,'Service 2 was down for the first hour of checked timeframe');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-03-05 11:00', '2019-03-05 13:00', NULL) , 50.0000,'Service 2 was down 1 out of 2 hours');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-03-05 12:00', '2019-03-05 13:00', NULL) , 0.0000,'Service 2 was down during that period');
+SELECT tap.eq(idoreports_get_sla_ok_percent(2,'2019-03-05 13:00', '2019-03-05 14:00', NULL) , 0.0000,'Service 2 was down during that period');

--- a/schema/t/README.md
+++ b/schema/t/README.md
@@ -1,0 +1,19 @@
+Tests for the idoreports_get_sla_ok_percent() function
+======================================================
+
+These are myTAP tests. You need myTAP installed.
+
+These tests can be run with "my_virtualenv", "mytap" and "my_prove" like this:
+
+```
+my_virtualenv bash -c 'pushd ~/path/to/mytap; ./install.sh -t; mysql -e "CREATE DATABASE icinga"; popd; my_prove -D icinga t/0*.sql
+```
+
+N.B.: They deliberately fail (also, t/06-get_sla_ok_percent.sql is just a
+symlink to the "real thing", so adding a tap.plan() call would break stuff)!
+
+The only relevant part is "07-test-func.sql", which obviously should _not_
+fail. 
+
+Having an overall fail allows to look into the db by simply adding "-s" to the
+my_virtualenv call above.


### PR DESCRIPTION
These tests create and populate a minimal database schema, then exercise the
idoreports_get_sla_ok_percent() function with various arguments.