### PR TITLE
Ignore objects in breakdown reports that have not yet been monitored in the selected period

### DIFF
--- a/library/Idoreports/HostSlaReport.php
+++ b/library/Idoreports/HostSlaReport.php
@@ -50,14 +50,17 @@ class HostSlaReport extends IdoReport
                 case 'day':
                     $interval = new \DateInterval('P1D');
                     $format = 'Y-m-d';
+                    $boundary = false;
                     break;
                 case 'week':
                     $interval = new \DateInterval('P1W');
                     $format = 'Y-\WW';
+                    $boundary = 'monday next week midnight';
                     break;
                 case 'month':
                     $interval = new \DateInterval('P1M');
                     $format = 'Y-m';
+                    $boundary = 'first day of next month midnight';
                     break;
             }
 
@@ -67,7 +70,7 @@ class HostSlaReport extends IdoReport
 
             $rows = [];
 
-            foreach ($this->yieldTimerange($timerange, $interval) as list($start, $end)) {
+            foreach ($this->yieldTimerange($timerange, $interval, $boundary) as list($start, $end)) {
                 foreach ($this->fetchHostSla(new Timerange($start, $end), $config) as $row) {
                     if ($row->sla === null) {
                         continue;

--- a/library/Idoreports/HostSlaReport.php
+++ b/library/Idoreports/HostSlaReport.php
@@ -69,6 +69,10 @@ class HostSlaReport extends IdoReport
 
             foreach ($this->yieldTimerange($timerange, $interval) as list($start, $end)) {
                 foreach ($this->fetchHostSla(new Timerange($start, $end), $config) as $row) {
+                    if ($row->sla === null) {
+                        continue;
+                    }
+
                     $rows[] = (new ReportRow())
                         ->setDimensions([$row->host_display_name, $start->format($format)])
                         ->setValues([(float) $row->sla]);

--- a/library/Idoreports/ServiceSlaReport.php
+++ b/library/Idoreports/ServiceSlaReport.php
@@ -69,6 +69,10 @@ class ServiceSlaReport extends IdoReport
 
             foreach ($this->yieldTimerange($timerange, $interval) as list($start, $end)) {
                 foreach ($this->fetchServiceSla(new Timerange($start, $end), $config) as $row) {
+                    if ($row->sla === null) {
+                        continue;
+                    }
+
                     $rows[] = (new ReportRow())
                         ->setDimensions([$row->host_display_name, $row->service_display_name, $start->format($format)])
                         ->setValues([(float) $row->sla]);

--- a/library/Idoreports/ServiceSlaReport.php
+++ b/library/Idoreports/ServiceSlaReport.php
@@ -50,14 +50,17 @@ class ServiceSlaReport extends IdoReport
                 case 'day':
                     $interval = new \DateInterval('P1D');
                     $format = 'Y-m-d';
+                    $boundary = false;
                     break;
                 case 'week':
                     $interval = new \DateInterval('P1W');
                     $format = 'Y-\WW';
+                    $boundary = 'monday next week midnight';
                     break;
                 case 'month':
                     $interval = new \DateInterval('P1M');
                     $format = 'Y-m';
+                    $boundary = 'first day of next month midnight';
                     break;
             }
 
@@ -67,7 +70,7 @@ class ServiceSlaReport extends IdoReport
 
             $rows = [];
 
-            foreach ($this->yieldTimerange($timerange, $interval) as list($start, $end)) {
+            foreach ($this->yieldTimerange($timerange, $interval, $boundary) as list($start, $end)) {
                 foreach ($this->fetchServiceSla(new Timerange($start, $end), $config) as $row) {
                     if ($row->sla === null) {
                         continue;

--- a/schema/mysql/get_sla_ok_percent.sql
+++ b/schema/mysql/get_sla_ok_percent.sql
@@ -47,7 +47,7 @@ BEGIN
     RETURN NULL;
   END IF;
 
-SELECT sla_ok_percent INTO result FROM (
+SELECT CASE WHEN @last_state IS NULL THEN NULL ELSE sla_ok_percent END INTO result FROM (
 SELECT
   @sla_ok_seconds := SUM(
     CASE


### PR DESCRIPTION
Previously, objects that had not yet been monitored in the selected period were incorrectly reported with a SLA of 100 percent.

ref/NC/725496

refs #57 